### PR TITLE
Patched bug where EZ scheduler jobs were not re-initiating upon server reboot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nua",
   "private": true,
-  "version": "2.1.3",
+  "version": "2.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/app.js
+++ b/server/app.js
@@ -850,10 +850,11 @@ app.get('/checkjobreinitiation', async (req, res) => {
             }
             if (scheduledJobs[data.jobName] === undefined && data.toggleSched) { // reschedule jobs === undefined
                 if (data.oneTime) {
-                    if (data.date) { // job was in past, delete
+                    if (data.date) { // job was in past, delete or reschedule
                         let oneTimeScheduleDate = new Date(`${data.date} ${data.hour}:${data.minute}:00`);
                         let currentDate = new Date();
-                        console.log('oneTimeScheduleDate\t', oneTimeScheduleDate);
+                        // console.log('oneTimeScheduleDate\t', oneTimeScheduleDate);
+                        // console.log('currentDate\t', currentDate);
                         if (oneTimeScheduleDate < currentDate) {
                             console.log('Date was less than current date');
                             const deleteOldPrismaDate = await prisma.easySchedule.delete({ where: { id: data.id } });

--- a/server/app.js
+++ b/server/app.js
@@ -30,7 +30,7 @@ const { updateRecurringSchedule } = require('./ez_sched_funcs/update_ez_schedule
     })
 })();
 const prisma = new PrismaClient();
-
+// commented line to test docker build
 // create server & add middleware
 const app = express();
 app.use(cors());

--- a/server/ez_sched_funcs/addEasySchedule.js
+++ b/server/ez_sched_funcs/addEasySchedule.js
@@ -3,14 +3,13 @@ const { convertStringToBool } = require("../server_util_funcs/convert_string_to_
 
 
 async function addEasySchedule(deviceId, blockAllow, scheduleData, startNewJobTrue, prisma) {
-// async function addEasySchedule(deviceId, dateTime, blockAllow, scheduleData, startNewJobTrue, prisma) {
     const { month, day, minute, modifiedHour, ampm, date, oneTime, modifiedDaysOfTheWeek } = scheduleData;
 
     const deviceToSchedule = await prisma.device.findUnique({ where: { id: deviceId } }); // deviceToSchedule.macAddress
+    console.log("deviceToSchedule in addEZ\t", deviceToSchedule);
     let boolOneTime = convertStringToBool(oneTime);
     try {
         if (boolOneTime && startNewJobTrue) {
-            console.log("boolOneTime && startNewJobTrue from addEasy");
                 const addToDB = await prisma.easySchedule.create({ // create easySched
                     data: {
                         month: month,
@@ -20,7 +19,7 @@ async function addEasySchedule(deviceId, blockAllow, scheduleData, startNewJobTr
                         ampm: ampm,
                         date: date,
                         blockAllow: blockAllow,
-                        jobName: startNewJobTrue.name,
+                        jobName: startNewJobTrue?.name,
                         toggleSched: true,
                         oneTime: boolOneTime,
                         device: {
@@ -30,7 +29,6 @@ async function addEasySchedule(deviceId, blockAllow, scheduleData, startNewJobTr
                 });
 
         } else if (!boolOneTime && startNewJobTrue) {
-            console.log("!boolOneTime && startNewJobTrue from addEasy");
             const stringDays = convertDOWtoString(modifiedDaysOfTheWeek.join(""));
             const addToDB = await prisma.easySchedule.create({ // create easySched
                 data: {

--- a/server/ez_sched_funcs/nodeOneTimeScheduleRule.js
+++ b/server/ez_sched_funcs/nodeOneTimeScheduleRule.js
@@ -1,6 +1,6 @@
 const { convertToMilitaryTime } = require("../server_util_funcs/convert_to_military_time");
 const { dateFromDateString } = require("../server_util_funcs/ez_sched_utils/dateFromDateString");
-const { jobFunction } = require("../server_util_funcs/jobfunction");
+const { validDateModifier } = require('../server_util_funcs/ez_sched_utils/validDateModifier');
 const { addEasySchedule } = require("./addEasySchedule");
 
 async function nodeOneTimeScheduleRule(data, unifi, prisma, jobFunction, schedule) {
@@ -19,7 +19,7 @@ async function nodeOneTimeScheduleRule(data, unifi, prisma, jobFunction, schedul
         modifiedHour,
         oneTime
     };
-
+    // const dateTime = validDateModifier(year, month-1, day, modifiedHour, parseInt(minute));
     const dateTime = new Date(year, month-1, day, modifiedHour, parseInt(minute), 0);
     const startNewJobTrue = schedule.scheduleJob(dateTime, () => jobFunction(blockAllow, deviceToSchedule?.macAddress, oneTime, unifi, prisma));
     addEasySchedule(deviceId, blockAllow, scheduleData, startNewJobTrue, prisma); // -- do easy schedule in end point, not in function?

--- a/server/ez_sched_funcs/nodeRecurringScheduleRule.js
+++ b/server/ez_sched_funcs/nodeRecurringScheduleRule.js
@@ -21,14 +21,8 @@ async function nodeScheduleRecurrenceRule(data, unifi, prisma, jobFunction, sche
         modifiedDaysOfTheWeek,
         oneTime
     }
-    console.log('modifiedHour\t', modifiedHour);
-    console.log('hour\t', hour, typeof hour);
-    console.log('minute\t', minute, typeof minute);
-    // const daysToInt = days.split("").map((day) => parseInt(day));
     const rule = new schedule.RecurrenceRule();
-    // const dateTime = new Date(year, month-1, day, modifiedHour, parseInt(minute), 0);
-    const daysOfTheWeek = modifiedDaysOfTheWeek;
-    // rule.dayOfWeek = [...daysToInt];
+
     rule.dayOfWeek = [...modifiedDaysOfTheWeek];
     // rule.dayOfWeek = [...daysOfTheWeek];
     rule.hour = modifiedHour;

--- a/server/ez_sched_funcs/update_ez_schedules/updateOneTimeSchedule.js
+++ b/server/ez_sched_funcs/update_ez_schedules/updateOneTimeSchedule.js
@@ -3,9 +3,9 @@ const { dateFromDateString } = require("../../server_util_funcs/ez_sched_utils/d
 
 
 async function updateOneTimeSchedule(data, unifi, prisma, jobFunction, schedule) {
-    const { date, hour, minute, ampm, oneTime, deviceId, scheduletype } = data;
+    const { date, hour, minute, ampm, oneTime, deviceId, blockAllow } = data;
     const deviceToSchedule = await prisma.device.findUnique({ where: { id: deviceId } });
-    const blockAllow = scheduletype;
+    console.log('scheduletype from one time\t', scheduletype)
 
     const { year, month, day } = dateFromDateString(date);
     const modifiedHour = convertToMilitaryTime(ampm, hour);

--- a/server/ez_sched_funcs/update_ez_schedules/updateOneTimeSchedule.js
+++ b/server/ez_sched_funcs/update_ez_schedules/updateOneTimeSchedule.js
@@ -1,18 +1,17 @@
 const { convertToMilitaryTime } = require("../../server_util_funcs/convert_to_military_time");
 const { dateFromDateString } = require("../../server_util_funcs/ez_sched_utils/dateFromDateString");
+const { validDateModifier } = require('../../server_util_funcs/ez_sched_utils/validDateModifier');
 
 
 async function updateOneTimeSchedule(data, unifi, prisma, jobFunction, schedule) {
     const { date, hour, minute, ampm, oneTime, deviceId, blockAllow } = data;
     const deviceToSchedule = await prisma.device.findUnique({ where: { id: deviceId } });
-    console.log('scheduletype from one time\t', scheduletype)
 
     const { year, month, day } = dateFromDateString(date);
-    const modifiedHour = convertToMilitaryTime(ampm, hour);
-    const dateTime = new Date(year, month-1, day, modifiedHour, parseInt(minute), 0);
+    // we do not need modified hour here, as the DB provides already modified hour, only need to pre-cursor zero's (validDateMofidier)
+    const dateTime = validDateModifier(year, month-1, day, hour, parseInt(minute), 0); // month -1 (JS starts month @ 0, db stores it as proper month)
 
     const startNewJobTrue = schedule.scheduleJob(dateTime, () => jobFunction(blockAllow, deviceToSchedule?.macAddress, oneTime, unifi, prisma));
-
     return startNewJobTrue;
 }
 

--- a/server/ez_sched_funcs/update_ez_schedules/updateRecurringSchedule.js
+++ b/server/ez_sched_funcs/update_ez_schedules/updateRecurringSchedule.js
@@ -1,14 +1,22 @@
+const { convertToMilitaryTime } = require("../../server_util_funcs/convert_to_military_time");
 
 
 async function updateRecurringSchedule(data, unifi, prisma, jobFunction, schedule) {
-    const { date, hour, minute, ampm, modifiedDaysOfTheWeek, deviceId, oneTime, scheduletype, days } = data; // gets data from
-    console.log('modifiedDaysOfTheWeek\t', modifiedDaysOfTheWeek);
-    console.log('Array.isArray modifiedDaysOfTheWeek\t', Array.isArray(modifiedDaysOfTheWeek));
+    const { date, hour, minute, ampm, modifiedDaysOfTheWeek, deviceId, oneTime, blockAllow, days } = data; // gets data from
+    // console.log('modifiedDaysOfTheWeek\t', modifiedDaysOfTheWeek);
+    // console.log('Array.isArray modifiedDaysOfTheWeek\t', Array.isArray(modifiedDaysOfTheWeek));
     // console.log("days from updaterecurringsched\t", days);
     const deviceToSchedule = await prisma.device.findUnique({ where: { id: deviceId } });
     // const { year, month, day } = dateFromDateString(date);
-    // const modifiedHour = convertToMilitaryTime(ampm, parseInt(hour));
-    const blockAllow = scheduletype;
+    const modifiedHour = convertToMilitaryTime(ampm, parseInt(hour));
+    // console.log('modifiedHour\t', modifiedHour);
+    console.log('blockAllow\t', blockAllow);
+
+    // console.log('modifiedHour\t', modifiedHour);
+    // console.log('modifiedHour\t', typeof modifiedHour);
+    // console.log('hour\t', hour);
+    // console.log('typeof hour\t', typeof hour);
+    // console.log('minute\t', minute, typeof minute);
 
     // console.log("days\t", days, typeof days) // 07 18 2024, days is not passed from the front end or in routes/ezscheduleroutes.js // will be undefined
     // const daysToInt = days.split("").map((day) => parseInt(day)); // look deeper into why modifiedDaysOfTheWeek was not iterable upon job re-initiation on outdated onetime jobs
@@ -17,9 +25,26 @@ async function updateRecurringSchedule(data, unifi, prisma, jobFunction, schedul
     rule.dayOfWeek = [...modifiedDaysOfTheWeek]; // commented out 07 12 2024 && commented back in 07 18 2024
     // rule.dayOfWeek = [...daysToInt];
     // rule.dayOfWeek = [...daysOfTheWeek];
+    // rule.hour = modifiedHour;
     rule.hour = hour;
     rule.minute = minute;
+    // rule.tz = "Etc/UTC";
+    // console.log("rule\t", rule);
     const startNewJobTrue = schedule.scheduleJob(rule, () => jobFunction(blockAllow, deviceToSchedule?.macAddress, oneTime, unifi, prisma));
+    // await new Promise(res => setTimeout(res, 2000));
+    // console.log('startNewJobTrue from updateRecurringSched\t', startNewJobTrue.nextInvocation())
+    // startNewJobTrue.cancelNext(true)
+    // startNewJobTrue.reschedule({ spec: true });
+    // let adjust = startNewJobTrue.nextInvocation();
+    // console.log('adjust\t', adjust);
+    // console.log('startNewJobTrue.name\t', startNewJobTrue.name);
+    // console.log('schedule\t', schedule.scheduledJobs[startNewJobTrue.name].pendingInvocations[0])
+    // adjust._date.ts = "2024-12-25T16:32:00.000-05:00";
+    // console.log('startNewJobTrue.nextInvocation()\t', startNewJobTrue.nextInvocation())
+
+    // console.log('startNewJobTrue?.pendingInvocations[0].job\t', startNewJobTrue?.pendingInvocations[0].job);
+    // console.log('startNewJobTrue?.pendingInvocations[0].FIREDATE\t', startNewJobTrue?.pendingInvocations[0].fireDate);
+    // console.log('startNewJobTrue?.pendingInvocations[0].recurrenceRule\t', startNewJobTrue?.pendingInvocations[0].recurrenceRule);
 
     return startNewJobTrue;
 }

--- a/server/ez_sched_funcs/update_ez_schedules/updateRecurringSchedule.js
+++ b/server/ez_sched_funcs/update_ez_schedules/updateRecurringSchedule.js
@@ -3,48 +3,14 @@ const { convertToMilitaryTime } = require("../../server_util_funcs/convert_to_mi
 
 async function updateRecurringSchedule(data, unifi, prisma, jobFunction, schedule) {
     const { date, hour, minute, ampm, modifiedDaysOfTheWeek, deviceId, oneTime, blockAllow, days } = data; // gets data from
-    // console.log('modifiedDaysOfTheWeek\t', modifiedDaysOfTheWeek);
-    // console.log('Array.isArray modifiedDaysOfTheWeek\t', Array.isArray(modifiedDaysOfTheWeek));
-    // console.log("days from updaterecurringsched\t", days);
     const deviceToSchedule = await prisma.device.findUnique({ where: { id: deviceId } });
-    // const { year, month, day } = dateFromDateString(date);
     const modifiedHour = convertToMilitaryTime(ampm, parseInt(hour));
-    // console.log('modifiedHour\t', modifiedHour);
-    console.log('blockAllow\t', blockAllow);
-
-    // console.log('modifiedHour\t', modifiedHour);
-    // console.log('modifiedHour\t', typeof modifiedHour);
-    // console.log('hour\t', hour);
-    // console.log('typeof hour\t', typeof hour);
-    // console.log('minute\t', minute, typeof minute);
-
-    // console.log("days\t", days, typeof days) // 07 18 2024, days is not passed from the front end or in routes/ezscheduleroutes.js // will be undefined
-    // const daysToInt = days.split("").map((day) => parseInt(day)); // look deeper into why modifiedDaysOfTheWeek was not iterable upon job re-initiation on outdated onetime jobs
     const rule = new schedule.RecurrenceRule();
     // rule.dayOfWeek = [...daysToInt]; // commented out 07/18/2024, days is not passed from front end, modifiedDOTW is...
     rule.dayOfWeek = [...modifiedDaysOfTheWeek]; // commented out 07 12 2024 && commented back in 07 18 2024
-    // rule.dayOfWeek = [...daysToInt];
-    // rule.dayOfWeek = [...daysOfTheWeek];
-    // rule.hour = modifiedHour;
     rule.hour = hour;
     rule.minute = minute;
-    // rule.tz = "Etc/UTC";
-    // console.log("rule\t", rule);
     const startNewJobTrue = schedule.scheduleJob(rule, () => jobFunction(blockAllow, deviceToSchedule?.macAddress, oneTime, unifi, prisma));
-    // await new Promise(res => setTimeout(res, 2000));
-    // console.log('startNewJobTrue from updateRecurringSched\t', startNewJobTrue.nextInvocation())
-    // startNewJobTrue.cancelNext(true)
-    // startNewJobTrue.reschedule({ spec: true });
-    // let adjust = startNewJobTrue.nextInvocation();
-    // console.log('adjust\t', adjust);
-    // console.log('startNewJobTrue.name\t', startNewJobTrue.name);
-    // console.log('schedule\t', schedule.scheduledJobs[startNewJobTrue.name].pendingInvocations[0])
-    // adjust._date.ts = "2024-12-25T16:32:00.000-05:00";
-    // console.log('startNewJobTrue.nextInvocation()\t', startNewJobTrue.nextInvocation())
-
-    // console.log('startNewJobTrue?.pendingInvocations[0].job\t', startNewJobTrue?.pendingInvocations[0].job);
-    // console.log('startNewJobTrue?.pendingInvocations[0].FIREDATE\t', startNewJobTrue?.pendingInvocations[0].fireDate);
-    // console.log('startNewJobTrue?.pendingInvocations[0].recurrenceRule\t', startNewJobTrue?.pendingInvocations[0].recurrenceRule);
 
     return startNewJobTrue;
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuaserver",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/server/server_util_funcs/ez_sched_utils/validDateModifier.js
+++ b/server/server_util_funcs/ez_sched_utils/validDateModifier.js
@@ -1,0 +1,30 @@
+
+
+function validDateModifier(year, month, day, modifiedHour, minute) {
+    if (year === undefined
+        || month === undefined
+        || day === undefined
+        || modifiedHour === undefined
+        || minute === undefined) { throw new Error("undefined date value passed") };
+
+    let validModifiedHour = modifiedHour.toString();
+    let validMinute = minute.toString();
+    let validMonth = month.toString();
+    let validDay = day.toString();
+    let z = 0;
+    if (validModifiedHour.length < 2) {
+        validModifiedHour = z + validModifiedHour;
+    }
+    if (validMinute.length < 2) {
+        validMinute = z + validMinute;
+    }
+    if (validMonth.length < 2) {
+        validMonth = z + validMonth;
+    }
+    if (validDay.length < 2) {
+        validDay = z + validDay;
+    }
+    const validDate = new Date(year, validMonth, validDay, validModifiedHour, validMinute, 0);
+    return validDate;
+}
+module.exports = { validDateModifier };

--- a/server/server_util_funcs/jobfunction.js
+++ b/server/server_util_funcs/jobfunction.js
@@ -2,16 +2,17 @@ const { deleteCompletedJobs } = require("./ez_sched_utils/deleteCompletedJobs");
 const { red } = require("./red");
 
 const jobFunction = async (crontype, macAddress, oneTime, unifi, prisma) => { // for crons
+
     try {
         if (crontype === 'allow') {
             console.log('unifi === undefined \t', unifi === undefined);
-            const confirmAllow = await unifi.unblockClient(macAddress);
+            const confirmAllow = await unifi?.unblockClient(macAddress);
             console.log(`${macAddress} has been unblocked: ${confirmAllow}`);
             if (oneTime) {
                 deleteCompletedJobs(prisma);
             }
         } else if (crontype === 'block') {
-            const confirmBlocked = await unifi.blockClient(macAddress);
+            const confirmBlocked = await unifi?.blockClient(macAddress);
             console.log(`${macAddress} has been blocked: ${confirmBlocked}`);
             if (oneTime) {
                 deleteCompletedJobs(prisma);

--- a/server/server_util_funcs/jobfunction.js
+++ b/server/server_util_funcs/jobfunction.js
@@ -2,8 +2,8 @@ const { deleteCompletedJobs } = require("./ez_sched_utils/deleteCompletedJobs");
 const { red } = require("./red");
 
 const jobFunction = async (crontype, macAddress, oneTime, unifi, prisma) => { // for crons
-
     try {
+        if (crontype === undefined) throw new Error("**block/allow must be specified for jobFunction, undefined was passed!**");
         if (crontype === 'allow') {
             console.log('unifi === undefined \t', unifi === undefined);
             const confirmAllow = await unifi?.unblockClient(macAddress);

--- a/src/components/AdminConsole.jsx
+++ b/src/components/AdminConsole.jsx
@@ -163,7 +163,7 @@ export default function AdminConsole()
                     if (cronData.ok) {
                         const cronJobCheckData = await cronData.json();
                         setCronJobChecked(cronJobCheckData);
-                        // console.log('Cron Job Check Data: ', cronJobCheckData);
+                        console.log('Cron Job Check Data: ', cronJobCheckData);
                     }
                 } catch (error) {
                     // if (error) throw error; // prev 03/4/2024

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -83,7 +83,7 @@ export default function Navbar({ themeValue, callBackChanged })
                   <Link to="/seeallapps"><li className="font-bold text-lg"><a>See All Apps</a></li></Link>
                 </ul>
                 <div className={`${open ? "absolute left-5 bottom-5" : "hidden"}`}>
-                  <div className="badge badge-outline">Version&nbsp;<span className="text-primary">2.1.3</span></div>
+                  <div className="badge badge-outline">Version&nbsp;<span className="text-primary">2.1.4</span></div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
An improper value was being passed to the job function for the node-schedule callback, rendering the job to not fire. In addition to updating the updateEasySchedule functions, another bug was found where improper date formatting was setting the onetime schedule to the improper execution date.